### PR TITLE
Experimental notch adjustment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ fp-info-cache
 *.ses
 # vim swap files
 *.swp
+# vim config file
+*.vimrc

--- a/PhobGCC.ino
+++ b/PhobGCC.ino
@@ -12,7 +12,7 @@
 
 //Uncomment the appropriate include line for your hardware.
 //#include "src/Phob1_0Teensy3_2.h"
-#include "src/Phob1_1Teensy3_2.h"
+//#include "src/Phob1_1Teensy3_2.h"
 //#include "src/Phob1_1Teensy4_0.h"
 
 using namespace Eigen;

--- a/PhobGCC.ino
+++ b/PhobGCC.ino
@@ -1005,8 +1005,10 @@ void readButtons(){
 	//Undo Calibration using Z-button
 	if(hardwareZ && _undoCal && !_undoCalPressed) {
 		_undoCalPressed = true;
-		if(_currentCalStep % 2 == 0 && _currentCalStep != 32 && _currentCalStep != 0) {
+		if(_currentCalStep % 2 == 0 && _currentCalStep < 32 && _currentCalStep != 0 ) {
 			_currentCalStep --;
+			_currentCalStep --;
+		} else if(_currentCalStep > 32) {
 			_currentCalStep --;
 		}
 	} else if(!hardwareZ) {

--- a/PhobGCC.ino
+++ b/PhobGCC.ino
@@ -2367,6 +2367,7 @@ void stripCalPoints(float calPointsX[], float calPointsY[], float strippedPoints
  * This seems redundant but we're feeding it coordinates without non-diagonal notches
  */
 void transformCalPoints(float xInput[], float yInput[], float xOutput[], float yOutput[], float fitCoeffsX[], float fitCoeffsY[], float affineCoeffs[][6], float boundaryAngles[]){
+	Serial.println("transformed cleaned original calibration points are:");
 	for(int i=0; i < _noOfNotches+1; i++){
 		float xValue = linearize(xInput[i], fitCoeffsX);
 		float yValue = linearize(yInput[i], fitCoeffsY);
@@ -2375,6 +2376,9 @@ void transformCalPoints(float xInput[], float yInput[], float xOutput[], float y
 		notchRemap(xValue, yValue, &outX, &outY, affineCoeffs, boundaryAngles, _noOfNotches);
 		xOutput[i] = outX;
 		yOutput[i] = outY;
+		Serial.print(outX);
+		Serial.print(",");
+		Serial.println(outY);
 	}
 }
 /*

--- a/PhobGCC.ino
+++ b/PhobGCC.ino
@@ -2327,15 +2327,16 @@ void angleOnSphere(const float x, const float y, float& angle){
 /*
  * stripCalPoints removes the notches from un-cleaned cal points
  * this is so we can get the original values of the notches after the affine transform.
+ * there need to be _noOfCalibrationPoints values in the inputs and outputs.
  */
 void stripCalPoints(float calPointsX[], float calPointsY[], float strippedPointsY[], float strippedPointsX[]){
 	for(int i=0; i < _noOfCalibrationPoints; i++){
-		if(_notchStatusDefaults[1+((i-1)/2)]==1){//non-cardinal non-diagonal notch
+		//start off by just copying them wholesale
+		strippedPointsX[i] = calPointsX[i];
+		strippedPointsY[i] = calPointsY[i];
+		if((i+1)%4 == 0){//non-cardinal non-diagonal notch (every fourth starting at index 3)
 			strippedPointsX[i] = calPointsX[0];//set equal to origin
 			strippedPointsY[i] = calPointsY[0];
-		}else{
-			strippedPointsX[i] = calPointsX[i];//otherwise just copy
-			strippedPointsY[i] = calPointsY[i];
 		}
 	}
 }

--- a/PhobGCC.ino
+++ b/PhobGCC.ino
@@ -1050,13 +1050,15 @@ void readButtons(){
 				//notchCalibrate again
 				notchCalibrate(_cleanedPointsX, _cleanedPointsY, _notchPointsX, _notchPointsY, _noOfNotches, _cAffineCoeffs, _cBoundaryAngles);
 			}
+			/*
 			int notchIndex = _notchAdjOrder[_currentCalStep-_noOfCalibrationPoints];
 			while(_currentCalStep >= _noOfCalibrationPoints && _cNotchStatus[notchIndex] == _tertiaryNotchInactive && _currentCalStep <= _noOfCalibrationPoints + _noOfAdjNotches){//this non-diagonal notch was not calibrated
 				//skip to the next valid notch
 				_currentCalStep++;
 				notchIndex = _notchAdjOrder[_currentCalStep-_noOfCalibrationPoints];
 			}
-			if(_currentCalStep >= _noOfCalibrationPoints + _noOfAdjNotches){//two times for collection, one more for adjust
+			*/
+			if(_currentCalStep >= _noOfCalibrationPoints + _noOfAdjNotches){//done adjusting notches
 				Serial.println("finished adjusting notches for the C stick");
 				EEPROM.put(_eepromCPointsX,_tempCalPointsX);
 				EEPROM.put(_eepromCPointsY,_tempCalPointsY);
@@ -1127,7 +1129,7 @@ void readButtons(){
 				notchIndex = _notchAdjOrder[_currentCalStep-_noOfCalibrationPoints];
 			}
 			*/
-			if(_currentCalStep >= _noOfCalibrationPoints + _noOfAdjNotches){//two times for collection, one more for adjust
+			if(_currentCalStep >= _noOfCalibrationPoints + _noOfAdjNotches){//done adjusting notches
 				Serial.println("finished adjusting notches for the A stick");
 				EEPROM.put(_eepromAPointsX,_tempCalPointsX);
 				EEPROM.put(_eepromAPointsY,_tempCalPointsY);

--- a/PhobGCC.ino
+++ b/PhobGCC.ino
@@ -12,7 +12,7 @@
 
 //Uncomment the appropriate include line for your hardware.
 //#include "src/Phob1_0Teensy3_2.h"
-//#include "src/Phob1_1Teensy3_2.h"
+#include "src/Phob1_1Teensy3_2.h"
 //#include "src/Phob1_1Teensy4_0.h"
 
 using namespace Eigen;
@@ -1056,7 +1056,7 @@ void readButtons(){
 				//notchCalibrate again
 				notchCalibrate(_cleanedPointsX, _cleanedPointsY, _notchPointsX, _notchPointsY, _noOfNotches, _cAffineCoeffs, _cBoundaryAngles);
 			}
-			int notchIndex = _notchAdjOrder[_currentCalStep-_noOfCalibrationPoints];
+			int notchIndex = min(_notchAdjOrder[_currentCalStep-_noOfCalibrationPoints], _noOfAdjNotches-1);//limit this so it doesn't access outside the array bounds
 			while((_currentCalStep >= _noOfCalibrationPoints) && (_cNotchStatus[notchIndex] == _tertiaryNotchInactive) && (_currentCalStep < _noOfCalibrationPoints + _noOfAdjNotches)){//this non-diagonal notch was not calibrated
 				//skip to the next valid notch
 				_currentCalStep++;
@@ -1116,7 +1116,7 @@ void readButtons(){
 				//notchCalibrate again
 				notchCalibrate(_cleanedPointsX, _cleanedPointsY, _notchPointsX, _notchPointsY, _noOfNotches, _aAffineCoeffs, _aBoundaryAngles);
 			}
-			int notchIndex = _notchAdjOrder[_currentCalStep-_noOfCalibrationPoints];
+			int notchIndex = min(_notchAdjOrder[_currentCalStep-_noOfCalibrationPoints], _noOfAdjNotches-1);//limit this so it doesn't access outside the array bounds
 			while((_currentCalStep >= _noOfCalibrationPoints) && (_aNotchStatus[notchIndex] == _tertiaryNotchInactive) && (_currentCalStep < _noOfCalibrationPoints + _noOfAdjNotches)){//this non-diagonal notch was not calibrated
 				//skip to the next valid notch
 				_currentCalStep++;

--- a/PhobGCC.ino
+++ b/PhobGCC.ino
@@ -1011,6 +1011,21 @@ void readButtons(){
 		} else if(_currentCalStep > 32) {
 			_currentCalStep --;
 		}
+		if(!_calAStick){
+			int notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
+			while((_currentCalStep >= _noOfCalibrationPoints) && (_cNotchStatus[notchIndex] == _tertiaryNotchInactive) && (_currentCalStep < _noOfCalibrationPoints + _noOfAdjNotches)){//this non-diagonal notch was not calibrated
+				//skip to the next valid notch
+				_currentCalStep--;
+				notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
+			}
+		} else if(_calAStick){
+			int notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
+			while((_currentCalStep >= _noOfCalibrationPoints) && (_aNotchStatus[notchIndex] == _tertiaryNotchInactive) && (_currentCalStep < _noOfCalibrationPoints + _noOfAdjNotches)){//this non-diagonal notch was not calibrated
+				//skip to the next valid notch
+				_currentCalStep--;
+				notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
+			}
+		}
 	} else if(!hardwareZ) {
 		_undoCalPressed = false;
 	}
@@ -1056,11 +1071,11 @@ void readButtons(){
 				//notchCalibrate again
 				notchCalibrate(_cleanedPointsX, _cleanedPointsY, _notchPointsX, _notchPointsY, _noOfNotches, _cAffineCoeffs, _cBoundaryAngles);
 			}
-			int notchIndex = min(_notchAdjOrder[_currentCalStep-_noOfCalibrationPoints], _noOfAdjNotches-1);//limit this so it doesn't access outside the array bounds
+			int notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
 			while((_currentCalStep >= _noOfCalibrationPoints) && (_cNotchStatus[notchIndex] == _tertiaryNotchInactive) && (_currentCalStep < _noOfCalibrationPoints + _noOfAdjNotches)){//this non-diagonal notch was not calibrated
 				//skip to the next valid notch
 				_currentCalStep++;
-				notchIndex = min(_notchAdjOrder[_currentCalStep-_noOfCalibrationPoints], _noOfAdjNotches-1);//limit this so it doesn't access outside the array bounds
+				notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
 			}
 			if(_currentCalStep >= _noOfCalibrationPoints + _noOfAdjNotches){//done adjusting notches
 				Serial.println("finished adjusting notches for the C stick");
@@ -1116,11 +1131,11 @@ void readButtons(){
 				//notchCalibrate again
 				notchCalibrate(_cleanedPointsX, _cleanedPointsY, _notchPointsX, _notchPointsY, _noOfNotches, _aAffineCoeffs, _aBoundaryAngles);
 			}
-			int notchIndex = min(_notchAdjOrder[_currentCalStep-_noOfCalibrationPoints], _noOfAdjNotches-1);//limit this so it doesn't access outside the array bounds
+			int notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
 			while((_currentCalStep >= _noOfCalibrationPoints) && (_aNotchStatus[notchIndex] == _tertiaryNotchInactive) && (_currentCalStep < _noOfCalibrationPoints + _noOfAdjNotches)){//this non-diagonal notch was not calibrated
 				//skip to the next valid notch
 				_currentCalStep++;
-				notchIndex = min(_notchAdjOrder[_currentCalStep-_noOfCalibrationPoints], _noOfAdjNotches-1);//limit this so it doesn't access outside the array bounds
+				notchIndex = _notchAdjOrder[min(_currentCalStep-_noOfCalibrationPoints, _noOfAdjNotches-1)];//limit this so it doesn't access outside the array bounds
 			}
 			if(_currentCalStep >= _noOfCalibrationPoints + _noOfAdjNotches){//done adjusting notches
 				Serial.println("finished adjusting notches for the A stick");


### PR DESCRIPTION
This changes the calibration procedure.

First it goes through collecting data: cardinals, then diagonals, then optionally notches.
Then it does up to 12 more steps, in which you can adjust the notches while viewing the live output of the stick.
Press B to reset to default.

This needs testing with a controller shell that actually has notches.